### PR TITLE
Minor tooltip fixes

### DIFF
--- a/gui/darc.c
+++ b/gui/darc.c
@@ -433,7 +433,7 @@ tooltip_overlay (RobWidget* rw, cairo_t* cr, cairo_rectangle_t* ev)
 	cairo_set_source_rgba (cr, 0, 0, 0, .7);
 	cairo_fill (cr);
 
-	if (ui->tt_id < 4) {
+	if (ui->tt_id < 5) {
 		rounded_rectangle (cr, ui->tt_pos->x, ui->tt_pos->y,
 		                   ui->tt_pos->width + 2, ui->tt_pos->height + 1, 3);
 		cairo_set_source_rgba (cr, 1, 1, 1, .5);

--- a/gui/darc.c
+++ b/gui/darc.c
@@ -420,7 +420,7 @@ static bool
 tooltip_overlay (RobWidget* rw, cairo_t* cr, cairo_rectangle_t* ev)
 {
 	darcUI* ui = (darcUI*)rw->top;
-	assert (ui->tt_id >= 0 && ui->tt_id < 5);
+	assert (ui->tt_id >= 0 && ui->tt_id < 6);
 
 	cairo_save (cr);
 	cairo_rectangle_t event = { 0, 0, rw->area.width, rw->area.height };


### PR DESCRIPTION
I accidentally  build darc.lv2 without `-DNDEBUG`, and it started crashing with the following output (from standalone version):

```
x42-darc: ./gui/darc.c:424: bool tooltip_overlay(RobWidget*, cairo_t*, cairo_rectangle_t*): Assertion `ui->tt_id >= 0 && ui->tt_id < 5' failed.
Aborted (core dumped)
```

As I fixed that, I looked for other `tt_id` usages and discovered that 'Release' label was not highlighted when the tooltip was shown.